### PR TITLE
feat: add heading-link-separator setting and UI support

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -13,7 +13,7 @@ export type TranslationKey =
 	| 'wiki-link-copied' | 'callout-copied'
 	| 'format' | 'add-to-menu' | 'add-to-menu-desc' | 'show-notice' | 'show-notice-desc'
 	| 'add-extra-commands' | 'add-extra-commands-desc'
-	| 'use-heading-as-display' | 'use-heading-as-display-desc'  | 'block-id'
+	| 'use-heading-as-display' | 'use-heading-as-display-desc' | 'heading-link-separator' | 'heading-link-separator-desc' | 'block-id'
 	| 'use-frontmatter-as-display' | 'use-frontmatter-as-display-desc' | 'frontmatter-key' | 'frontmatter-key-desc'
 	| 'link-format'| 'link-format-desc' | 'markdown-link' | 'wiki-link' | 'contextual-copy'
 	| 'copy-current-file-link' | 'file-link-copied'
@@ -84,6 +84,8 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		'show-notice-desc': 'Show notification when content is copied',
 		'use-heading-as-display': 'Heading Link: Use heading as display text',
 		'use-heading-as-display-desc': 'Use the heading text as display text in copied heading links',
+		'heading-link-separator': 'Heading Link: Separator between filename and heading',
+		'heading-link-separator-desc': 'Customize the separator symbol between filename and heading (only shown when "Use heading as display text" is disabled)',
 		'link-format': 'Link format',
 		'link-format-desc': 'The format used when copying various types of links',
 		'markdown-link': 'Markdown link',
@@ -165,6 +167,8 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		'show-notice-desc': '复制内容时显示通知提示',
 		'use-heading-as-display': '标题链接：使用标题作为显示文本',
 		'use-heading-as-display-desc': '在复制的标题链接中，使用标题文本作为显示文本',
+		'heading-link-separator': '标题链接：文件名与标题间的连接符',
+		'heading-link-separator-desc': '自定义文件名与标题之间的连接符号（仅在禁用"使用标题作为显示文本"时显示）',
 		'link-format': '链接格式',
 		'link-format-desc': '复制各种链接时使用的格式',
 		'markdown-link': 'Markdown链接',
@@ -252,6 +256,8 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		'show-notice-desc': '複製內容時顯示通知提示',
 		'use-heading-as-display': '標題連結：使用標題作為顯示文本',
 		'use-heading-as-display-desc': '在複製的標題連結中，使用標題文本作為顯示文本',
+		'heading-link-separator': '標題連結：檔案名與標題間的連接符',
+		'heading-link-separator-desc': '自定義檔案名與標題之間的連接符號（僅在禁用「使用標題作為顯示文本」時顯示）',
 		'link-format': '連結格式',
 		'link-format-desc': '複製各種連結時使用的格式',
 		'markdown-link': 'Markdown連結',

--- a/src/main.ts
+++ b/src/main.ts
@@ -598,8 +598,9 @@ export default class EasyCopy extends Plugin {
 		// 根据设置决定显示文本
 		let displayText = selectedHeading;
 		if (!this.settings.useHeadingAsDisplayText) {
-			// 如果不使用标题作为显示文本，则使用"文件名#标题名"格式
-			displayText = `${filename}#${selectedHeading}`;
+			// 如果不使用标题作为显示文本，则使用"文件名{连接符}标题名"格式
+			const separator = this.settings.headingLinkSeparator || '#';
+			displayText = `${filename}${separator}${selectedHeading}`;
 		}
 		
 		let headingReferenceLink = "";
@@ -608,7 +609,7 @@ export default class EasyCopy extends Plugin {
 		// 根据设置选择链接格式
 		if (this.settings.linkFormat === LinkFormat.WIKILINK) {
 			// Wiki链接格式
-			if (this.settings.useHeadingAsDisplayText && filename === selectedHeading) {
+			if (filename === selectedHeading) {
 				// 特殊情况：当文件名与标题相同时，直接链接到文件
 				headingReferenceLink = `[[${filename}]]`;
 				noteFlag = 1;

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -70,7 +70,23 @@ export class EasyCopySettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.useHeadingAsDisplayText = value;
 					await this.plugin.saveSettings();
+					this.display(); // 重新渲染设置界面以显示或隐藏连接符设置
 				}));
+
+		// 新增：标题链接连接符设置，仅在禁用"使用标题作为显示文本"时显示
+		if (!this.plugin.settings.useHeadingAsDisplayText) {
+			new Setting(containerEl)
+				.setName(this.plugin.t('heading-link-separator'))
+				.setDesc(this.plugin.t('heading-link-separator-desc'))
+				.addText(text => text
+					.setPlaceholder('#')
+					.setValue(this.plugin.settings.headingLinkSeparator)
+					.onChange(async (value) => {
+						this.plugin.settings.headingLinkSeparator = value || '#';
+						await this.plugin.saveSettings();
+					})
+				);
+		}
 
 		// 新增：是否使用 frontmatter 属性作为显示文本
 		new Setting(containerEl)

--- a/src/type.ts
+++ b/src/type.ts
@@ -33,6 +33,7 @@ export interface EasyCopySettings {
     addExtraCommands: boolean;
     showNotice: boolean;
     useHeadingAsDisplayText: boolean;
+    headingLinkSeparator: string; // 文件名和标题间的连接符
     linkFormat: LinkFormat;
     customizeTargets: boolean;
     enableInlineCode: boolean;
@@ -59,6 +60,7 @@ export const DEFAULT_SETTINGS: EasyCopySettings = {
     addExtraCommands: true,
     showNotice: true,
     useHeadingAsDisplayText: true,
+    headingLinkSeparator: '#',
     linkFormat: LinkFormat.WIKILINK,
     customizeTargets: false,
     enableInlineCode: true,


### PR DESCRIPTION
Introduce a new setting `headingLinkSeparator (default '#')
customize the separator used between filename and heading when the
"Use heading as display text" option is disabled.

- Add `headingLinkSeparator` to settings type and defaults.
- Add localization keys and translations (en/zh/zh-TW) for the new
  setting and its description.
- Update settings UI to render a text input for the separator and
  re-render when "use heading as display text" toggles so the control
  shows/hides correctly.
- Use the configured separator when composing display text for heading
  links.
- Simplify a Wiki-link conditional to avoid redundant `useHeadingAsDisplayText`
  check when filename equals selected heading.

This allows users to customize the filename-heading delimiter for copied
heading links.