### PR TITLE
feat: add block display text limit settings

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -35,6 +35,8 @@ export type TranslationKey =
     | 'manual-block-id' | 'manual-block-id-desc'
     | 'modal-block-id' | 'modal-block-id-desc'
 	| 'auto-block-display-text' | 'auto-block-display-text-desc' 
+	| 'block-display-word-limit' | 'block-display-word-limit-desc'
+	| 'block-display-char-limit' | 'block-display-char-limit-desc' 
 	| 'generate-current-block-link-auto' | 'generate-current-block-link-manual'
     | 'error-block-id-empty' | 'error-block-id-invalid';
 
@@ -108,6 +110,10 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		'enable-link-desc': 'Enable copying link like [linktitle](linkurl) - the plugin will copy the title or the URL of the link based on the current cursor position.',
 		'auto-block-display-text': 'Generate display text for block links',
 		'auto-block-display-text-desc': 'If enabled, display text will be automatically added to generated block ID links',
+		'block-display-word-limit': 'Block Display Text: Word limit for English-like languages',
+		'block-display-word-limit-desc': 'Maximum number of words to show in block display text for space-separated languages (e.g., English "this is a sentence")',
+		'block-display-char-limit': 'Block Display Text: Character limit for CJK-like languages',
+		'block-display-char-limit-desc': 'Maximum number of characters to show in block display text for non-space-separated languages (e.g., Chinese "这是一句话") - This setting will be used when the first line contains non-ASCII characters.',
 		'enable-wikilink': 'Enable Wiki Link',
 		'enable-wikilink-desc': 'Enable copying of [[Wiki]] links',
 		
@@ -213,6 +219,10 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		'frontmatter-key-desc': '用于显示文本的笔记属性名（默认：title）',
 		'auto-block-display-text': '生成块链接的显示文本',
 		'auto-block-display-text-desc': '启用后，会自动为生成的块ID链接添加显示文本',
+		'block-display-word-limit': '块显示文本：英语类语言的单词数限制',
+		'block-display-word-limit-desc': '使用空格分隔的语言（如英语 "this is a sentence"）在块显示文本中显示的最大单词数',
+		'block-display-char-limit': '块显示文本：CJK 类语言的字符数限制',
+		'block-display-char-limit-desc': '非英语类语言（如中文 "这是一句话"）在块显示文本中显示的最大字符数——当第一行包含非ASCII字符时，会采用此设置。',
 	},
 	[Language.ZH_TW]: {
 		// 复制 Block ID
@@ -222,6 +232,10 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		'add-extra-commands-desc': '啟用後，會在命令面板中新增「複製當前筆記鏈接」和「生成並複製當前塊鏈接」命令',
 		'auto-block-display-text': '生成塊連結的顯示文本',
 		'auto-block-display-text-desc': '啟用後，會自動為生成的塊ID連結添加顯示文本',
+		'block-display-word-limit': '塊顯示文本：英語類語言的單詞數限制',
+		'block-display-word-limit-desc': '空格分隔語言（如 "this is a sentence"）在塊顯示文本中顯示的最大單詞數',
+		'block-display-char-limit': '塊顯示文本：CJK 類語言的字符數限制',
+		'block-display-char-limit-desc': '非空格分隔語言（如中文 "這是一句話"）在塊顯示文本中顯示的最大字符數——當第一行包含非ASCII字符時，會採用此設置。',
 		'manual-block-id': '手動輸入塊ID',
 		'manual-block-id-desc': '啟用後，可以在彈窗中手動輸入塊ID',
 		'modal-block-id': '輸入塊ID',

--- a/src/main.ts
+++ b/src/main.ts
@@ -530,10 +530,10 @@ export default class EasyCopy extends Plugin {
 			const isEnglish = /^[a-zA-Z\s,.!?"()\[-\]_\^\-\~:;0-9]*$/.test(text);
 
 			if (isEnglish) {
-				const wordLimit = 3;
+				const wordLimit = this.settings.blockDisplayWordLimit || 3;
 				displayText = text.trim().split(' ').slice(0, wordLimit).join(' ');
 			} else {
-				const charLimit = 5;
+				const charLimit = this.settings.blockDisplayCharLimit || 5;
 
 				const briefText = text;
 

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -153,9 +153,38 @@ export class EasyCopySettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.autoBlockDisplayText = value;
 					await this.plugin.saveSettings();
-					this.display();
+					this.display(); // 重新渲染以显示或隐藏相关设置
 				})
 			);
+
+		// 新增：块显示文本限制设置，仅在启用 autoBlockDisplayText 时显示
+		if (this.plugin.settings.autoBlockDisplayText) {
+			new Setting(containerEl)
+				.setName(this.plugin.t('block-display-word-limit'))
+				.setDesc(this.plugin.t('block-display-word-limit-desc'))
+				.addText(text => text
+					.setPlaceholder('3')
+					.setValue(String(this.plugin.settings.blockDisplayWordLimit))
+					.onChange(async (value) => {
+						const numValue = parseInt(value) || 3;
+						this.plugin.settings.blockDisplayWordLimit = Math.max(1, numValue);
+						await this.plugin.saveSettings();
+					})
+				);
+
+			new Setting(containerEl)
+				.setName(this.plugin.t('block-display-char-limit'))
+				.setDesc(this.plugin.t('block-display-char-limit-desc'))
+				.addText(text => text
+					.setPlaceholder('5')
+					.setValue(String(this.plugin.settings.blockDisplayCharLimit))
+					.onChange(async (value) => {
+						const numValue = parseInt(value) || 5;
+						this.plugin.settings.blockDisplayCharLimit = Math.max(1, numValue);
+						await this.plugin.saveSettings();
+					})
+				);
+		}
 
 		new Setting(containerEl)
 			.setName(this.plugin.t('target'))

--- a/src/type.ts
+++ b/src/type.ts
@@ -51,6 +51,8 @@ export interface EasyCopySettings {
     autoAddBlockId: boolean; // 是否自动添加 Block ID
     allowManualBlockId: boolean; // 是否允许手动输入 Block ID
     autoBlockDisplayText: boolean; // 自动为 Block 添加显示文本
+    blockDisplayWordLimit: number; // Block 显示文本英文单词限制（按空格分隔）
+    blockDisplayCharLimit: number; // Block 显示文本字符限制（非英文语言）
 }
 
 export const DEFAULT_SETTINGS: EasyCopySettings = {
@@ -78,4 +80,6 @@ export const DEFAULT_SETTINGS: EasyCopySettings = {
     autoAddBlockId: false, // 默认关闭
     allowManualBlockId: false, // 默认关闭
     autoBlockDisplayText: true,
+    blockDisplayWordLimit: 3, // 英文单词限制：3个单词
+    blockDisplayCharLimit: 5, // 字符限制：5个字符
 }


### PR DESCRIPTION
Add configurable limits for generated block display text and wire them
through UI, defaults, localization, and usage logic.

- Add blockDisplayWordLimit and blockDisplayCharLimit to settings with
  defaults (3 words, 5 chars).
- Expose new settings in the Settings tab show the two limit inputs
  only when autoBlockDisplayText is enabled and save changes.
- Use the configured limits in main generation logic (fall back to
  defaults if unset) to trim English-like text by words and other
  languages by characters.
- Add i18n keys and translations for labels and descriptions in all
  languages.

This allows users to control how much text is included when the plugin
auto-generates display text for block links.