### PR TITLE
Fix: encode spaces as %20 in Markdown link URLs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -569,12 +569,12 @@ export default class EasyCopy extends Plugin {
 		// displayText = "^"+displayText;
 		let blockIdLink = this.settings.linkFormat === LinkFormat.WIKILINK
 			? `[[${filename}#^${blockId}|${displayText}]]`
-			: `[${displayText}](${filename}#^${blockId})`;	 	// markdown 格式不能加，不然会变成内联脚注语法 [^xxx]
+			: `[${displayText}](${this.encodeMarkdownLinkUrl(filename)}#^${blockId})`;	 	// markdown 格式不能加，不然会变成内联脚注语法 [^xxx]
 
 		if (!autoDisplayText) {
 			blockIdLink = this.settings.linkFormat === LinkFormat.WIKILINK
 			? `[[${filename}#^${blockId}]]`
-			: `[](${filename}#^${blockId})`;
+			: `[](${this.encodeMarkdownLinkUrl(filename)}#^${blockId})`;
 		}
 
 		// 自动生成嵌入块
@@ -659,7 +659,8 @@ export default class EasyCopy extends Plugin {
 			}
 		} else {
 			// Markdown链接格式
-			headingReferenceLink = `[${displayText}](${filename}#${selectedHeading})`;
+			headingReferenceLink = `[${displayText}](${this.encodeMarkdownLinkUrl(`${filename}#${selectedHeading}`)})`;
+
 		}
 		
 		// 复制到剪贴板
@@ -706,7 +707,7 @@ export default class EasyCopy extends Plugin {
 		} else {
 			let path = file.path.replace(/\\/g, '/');
 			if (path.endsWith('.md')) path = path.slice(0, -3);
-			link = `[${display}](${path})`;
+			link = `[${display}](${this.encodeMarkdownLinkUrl(path)})`;
 		}
 		navigator.clipboard.writeText(link);
 		if (this.settings.showNotice) {
@@ -818,5 +819,9 @@ export default class EasyCopy extends Plugin {
 		// 从 localStorage 中获取 Obsidian 的语言设置
 		const lang = window.localStorage.getItem("language") || 'en';
 		return lang;
+	}
+
+	private encodeMarkdownLinkUrl(url: string): string {
+		return url.replace(/ /g, '%20');
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `encodeMarkdownLinkUrl` helper that encodes spaces as `%20` in the URL portion of generated Markdown links
- Applies it in `copyHeadingLink`, `copyBlockLink`, and `copyCurrentFileLink` — only in the Markdown format branch (wikilinks and display text are unaffected)

Closes #29

## Test plan

- [ ] Open a note with a multi-word filename (e.g. `My Notes`)
- [ ] Place cursor on a heading with spaces (e.g. `## Test Heading With Spaces`)
- [ ] Trigger Easy Copy with Markdown link format → verify URL contains `%20` instead of literal spaces
- [ ] Repeat for block ID links and file links
- [ ] Switch to Wiki link format → verify wikilinks are unchanged


🤖 Generated with [Claude Code](https://claude.com/claude-code)